### PR TITLE
fix headers for authentication

### DIFF
--- a/src/utils/authUtils.ts
+++ b/src/utils/authUtils.ts
@@ -61,10 +61,11 @@ export const getAccessToken = async (
   const response = await fetch(url, {
     method: "POST",
     headers: {
-      "Content-Type": "application/json",
+      Accept: "application/json",
+      "Content-Type": "application/x-www-form-urlencoded",
       Authorization: `Basic ${encodedCredentials}`,
     },
-    body: JSON.stringify({}),
+    body: "",
   });
 
   if (!response.ok) {


### PR DESCRIPTION
See https://docs.carbon-transparency.org/v2/#api-action-auth

Using the Content-Type `application/json` does not work on our service and is not in the spec.