### PR TITLE
Prod hotfix: Allow empty arrays in case of productOrSectorSpecificRules

### DIFF
--- a/src/schemas/v2_0_schema.ts
+++ b/src/schemas/v2_0_schema.ts
@@ -267,7 +267,6 @@ const sharedDefinitions = {
             },
           },
         },
-        minItems: 1,
         uniqueItems: true,
         description: "Product or sector specific rules applied.",
       },

--- a/src/schemas/v2_1_schema.ts
+++ b/src/schemas/v2_1_schema.ts
@@ -243,7 +243,6 @@ const sharedDefinitions = {
         items: {
           $ref: "#/definitions/ProductOrSectorSpecificRule",
         },
-        minItems: 1,
         uniqueItems: true,
         description: "Rules applied for calculating or allocating emissions.",
       },

--- a/src/schemas/v2_2_schema.ts
+++ b/src/schemas/v2_2_schema.ts
@@ -254,7 +254,6 @@ const sharedDefinitions = {
         items: {
           $ref: "#/definitions/ProductOrSectorSpecificRule",
         },
-        minItems: 1,
         uniqueItems: true,
         description: "Rules applied for calculating or allocating emissions.",
       },

--- a/src/schemas/v2_3_schema.ts
+++ b/src/schemas/v2_3_schema.ts
@@ -294,7 +294,6 @@ const sharedDefinitions = {
         items: {
           $ref: "#/definitions/ProductOrSectorSpecificRule",
         },
-        minItems: 1,
         uniqueItems: true,
         description: "Rules applied for calculating or allocating emissions.",
       },

--- a/src/schemas/v3_0_schema.ts
+++ b/src/schemas/v3_0_schema.ts
@@ -312,7 +312,6 @@ const sharedDefinitions = {
             },
           },
         },
-        minItems: 1,
         uniqueItems: true,
         description:
           "The product-specific or sector-specific rules applied for calculating or allocating GHG emissions.",


### PR DESCRIPTION
Closes #132 