### PR TITLE
Invalid token tests: only check for HTTP status code, not for JSON error object.

### DIFF
--- a/src/data/index.ts
+++ b/src/data/index.ts
@@ -1,9 +1,7 @@
 import { Kysely, sql, PostgresDialect } from 'kysely';
-import pg from 'pg';
-import config from '../config';
+import { Pool } from "pg";
 import { DB } from './types';
-
-const { Pool } = pg;
+import config from '../config';
 
 export const db = new Kysely<DB>({
     dialect: new PostgresDialect({

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -37,7 +37,7 @@ export interface TestCase {
   expectedStatusCodes?: number[];
   schema?: object;
   requestData?: any;
-  condition?: (response: any, responseHeaders: Headers) => boolean;
+  condition?: (body: any, messages: string[]) => boolean;
   conditionErrorMessage?: string;
   headers?: Record<string, string>;
   customUrl?: string;

--- a/src/test-cases/v2-test-cases.ts
+++ b/src/test-cases/v2-test-cases.ts
@@ -104,8 +104,8 @@ export const generateV2TestCases = ({
       endpoint: `/2/footprints/${footprints.data[0].id}`,
       expectedStatusCodes: [200],
       schema: singleFootprintResponseSchema,
-      condition: ({ data }) => {
-        return data.id === footprints.data[0].id;
+      condition: (body) => {
+        return body?.data?.id === footprints.data[0].id;
       },
       conditionErrorMessage: `Returned footprint does not match the requested footprint with id ${footprints.data[0].id}`,
       mandatoryVersion: ["V2.0", "V2.1", "V2.2", "V2.3"],
@@ -119,8 +119,8 @@ export const generateV2TestCases = ({
       endpoint: "/2/footprints",
       expectedStatusCodes: [200, 202],
       schema: responseSchema,
-      condition: ({ data }) => {
-        return data.length === footprints.data.length;
+      condition: (body) => {
+        return body?.data?.length === footprints.data.length;
       },
       conditionErrorMessage: "Number of footprints does not match",
       mandatoryVersion: ["V2.0", "V2.1", "V2.2", "V2.3"],
@@ -144,10 +144,12 @@ export const generateV2TestCases = ({
       method: "GET",
       endpoint: `/2/footprints`,
       expectedStatusCodes: [400, 401],
-      condition: ({ code }) => {
-        return code === "BadRequest";
+      condition: (body, messages) => {
+        if (body?.code !== "BadRequest") {
+          messages.push(`Warning: expected error code BadRequest but received ${body?.code}`);
+        }
+        return true;
       },
-      conditionErrorMessage: `Expected error code BadRequest in response.`,
       headers: {
         Authorization: `Bearer very-invalid-access-token-${randomString(16)}`,
       },
@@ -161,10 +163,12 @@ export const generateV2TestCases = ({
       method: "GET",
       endpoint: `/2/footprints/${footprints.data[0].id}`,
       expectedStatusCodes: [400, 401],
-      condition: ({ code }) => {
-        return code === "BadRequest";
+      condition: (body, messages) => {
+        if (body?.code !== "BadRequest") {
+          messages.push(`Warning: expected error code BadRequest but received ${body?.code}`);
+        }
+        return true;
       },
-      conditionErrorMessage: `Expected error code BadRequest in response.`,
       headers: {
         Authorization: `Bearer very-invalid-access-token-${randomString(16)}`,
       },
@@ -178,8 +182,8 @@ export const generateV2TestCases = ({
       method: "GET",
       endpoint: `/2/footprints/random-string-as-id-${randomString(16)}`,
       expectedStatusCodes: [400, 404],
-      condition: ({ code }) => {
-        return code === "NoSuchFootprint";
+      condition: (body) => {
+        return body?.code === "NoSuchFootprint";
       },
       conditionErrorMessage: `Expected error code NoSuchFootprint in response.`,
       mandatoryVersion: ["V2.0", "V2.1", "V2.2", "V2.3"],
@@ -200,11 +204,6 @@ export const generateV2TestCases = ({
       documentationUrl:
         "https://docs.carbon-transparency.org/pact-conformance-service/v2-test-cases-expected-results.html#test-case-9-attempt-authentication-through-http-non-https",
       requestData: authRequestData,
-      condition: (response) => {
-        return !response.data && !response.access_token;
-      },
-      conditionErrorMessage:
-        "Expected response to not include data or access_token property",
     },
     {
       name: "Test Case 10: Attempt ListFootprints through HTTP (non-HTTPS)",
@@ -215,10 +214,6 @@ export const generateV2TestCases = ({
       testKey: "TESTCASE#10",
       documentationUrl:
         "https://docs.carbon-transparency.org/pact-conformance-service/v2-test-cases-expected-results.html#test-case-10-attempt-listfootprints-through-http-non-https",
-      condition: (response) => {
-        return !response.data;
-      },
-      conditionErrorMessage: "Expected response to not include data property",
     },
     {
       name: "Test Case 11: Attempt GetFootprint through HTTP (non-HTTPS)",
@@ -231,10 +226,6 @@ export const generateV2TestCases = ({
       testKey: "TESTCASE#11",
       documentationUrl:
         "https://docs.carbon-transparency.org/pact-conformance-service/v2-test-cases-expected-results.html#test-case-11-attempt-getfootprint-through-http-non-https",
-      condition: (response) => {
-        return !response.data;
-      },
-      conditionErrorMessage: "Expected response to not include data property",
     },
     {
       name: "Test Case 12: Receive Asynchronous PCF Request",
@@ -352,8 +343,8 @@ export const generateV2TestCases = ({
         Authorization: `Bearer very-invalid-access-token-${randomString(16)}`,
         "Content-Type": "application/cloudevents+json; charset=UTF-8",
       },
-      condition: ({ code }) => {
-        return code === "BadRequest";
+      condition: (body) => {
+        return body?.code === "BadRequest";
       },
       mandatoryVersion: ["V2.2", "V2.3"],
       testKey: "TESTCASE#16",
@@ -382,10 +373,6 @@ export const generateV2TestCases = ({
       testKey: "TESTCASE#17",
       documentationUrl:
         "https://docs.carbon-transparency.org/pact-conformance-service/v2-test-cases-expected-results.html#test-case-17-attempt-action-events-through-http-non-https",
-      condition: (response) => {
-        return !response.data;
-      },
-      conditionErrorMessage: "Expected response to not include data property",
     },
     {
       name: "Test Case 18: OpenId Connect-based Authentication Flow",
@@ -417,8 +404,8 @@ export const generateV2TestCases = ({
       )}`,
       expectedStatusCodes: [200],
       schema: simpleResponseSchema,
-      condition: ({ data }) => {
-        return data.every(
+      condition: (body) => {
+        return body?.data?.every(
           (footprint: { created: Date }) =>
             footprint.created >= footprints.data[0].created
         );

--- a/src/utils/runTestCase.ts
+++ b/src/utils/runTestCase.ts
@@ -52,194 +52,119 @@ export const runTestCase = async (
   version: ApiVersion
 ): Promise<TestResult> => {
 
-  // TODO: This should throw an error instead of returning a failed test result. This is not
-  // something an end-user can correct, it can only be fixed by the developer.
-  if (!testCase.endpoint && !testCase.customUrl) {
-    return {
-      name: testCase.name,
-      status: TestCaseResultStatus.FAILURE,
-      errorMessage: "Either endpoint or customUrl must be provided",
-      mandatory: isMandatoryVersion(testCase, version),
-      testKey: testCase.testKey,
-      curlRequest: "N/A - Missing URL",
-      documentationUrl: testCase.documentationUrl,
-    };
-  }
-
-  // If this is a callback test case, it needs to be handled by the Event listener, see EventController.
-  // We will not make an actual HTTP request, but just return the TestCaseResult with PENDING state.
-  if (testCase.callback) {
-    return {
-      name: testCase.name,
-      status: TestCaseResultStatus.PENDING,
-      mandatory: isMandatoryVersion(testCase, version),
-      testKey: testCase.testKey,
-      curlRequest: generateCurlCommand(
-        `${config.CONFORMANCE_API}/${testCase.endpoint}`, 
-        testCase.method, {
-          "Content-Type": "application/json",
-          Authorization: `Bearer TOKEN`,
-        }, 
-        "{ 'todo': '<TODO>' }" 
-      ),
-      documentationUrl: testCase.documentationUrl,
-    };
-  }
-
+  // Determine the full URL for the request
   const url = testCase.customUrl || `${baseUrl}${testCase.endpoint}`;
 
-  const options: RequestInit = {
-    method: testCase.method,
-    headers: {
-      "Content-Type": "application/json",
-      Authorization: `Bearer ${accessToken}`,
-    },
+  // Determine headers and body for curl command generation
+  const headers = {
+    "Content-Type": "application/json",
+    Authorization: `Bearer ${accessToken}`,
+    ...testCase.headers,
   };
 
-  if (testCase.requestData) {
-    options.body =
-      typeof testCase.requestData === "string"
-        ? testCase.requestData
-        : JSON.stringify(testCase.requestData);
-  }
+  // Create the request body 
+  const body = typeof testCase.requestData === "string"
+    ? testCase.requestData
+    : JSON.stringify(testCase.requestData);
 
-  if (testCase.headers) {
-    options.headers = {
-      ...options.headers,
-      ...testCase.headers,
-    };
-  }
+  // Initialize the result object with default values
+  let result: TestResult = {
+    name: testCase.name,
+    mandatory: isMandatoryVersion(testCase, version),
+    testKey: testCase.testKey,
+    status: TestCaseResultStatus.SUCCESS, // Assume success, will change if any checks fail
+    curlRequest: generateCurlCommand(url, testCase.method, headers, body),
+    documentationUrl: testCase.documentationUrl,
+  };
 
-  // Generate curl command before making the actual request
-  const headers = options.headers as Record<string, string>;
-  const body = options.body as string | undefined;
-  const curlCmd = generateCurlCommand(url, testCase.method, headers, body);
+  // If this is a callback test case, the call will need to made by the tested API.
+  // That call is going to be handled by our Event listener, see EventController.
+  // We return the TestResult with PENDING status here.
+  if (testCase.callback) {
+    result.status = TestCaseResultStatus.PENDING;
+    headers.Authorization = `Bearer YOUR-TOKEN-HERE`;
+    // Generate curl command with placeholder token for documentation
+    result.curlRequest = generateCurlCommand(url, testCase.method, headers, body);
+    return result;
+  }
+  
+  let status = 0;
+  let text = null;
+  let data = null;
 
   try {
     const response = await fetch(url, {
-      ...options,
+      method: testCase.method,
+      body: body,
+      headers: headers,
       signal: AbortSignal.timeout(config.TESTCASE_TIMEOUT),
     });
-
-    if (testCase.expectHttpError === true) {
-      // If we expect an HTTP error, we consider the test successful if the response is not OK
-      return {
-        name: testCase.name,
-        status: response.ok
-          ? TestCaseResultStatus.FAILURE
-          : TestCaseResultStatus.SUCCESS,
-        mandatory: isMandatoryVersion(testCase, version),
-        testKey: testCase.testKey,
-        curlRequest: curlCmd,
-        documentationUrl: testCase.documentationUrl,
-      };
+    status = response.status;
+    text = await response.text();
+    if (text && response.headers.get("Content-Type")?.includes("application/json")) {
+      data = JSON.parse(text);
     }
-
-    if (
-      testCase.expectedStatusCodes &&
-      !testCase.expectedStatusCodes.includes(response.status)
-    ) {
-      return {
-        name: testCase.name,
-        status: TestCaseResultStatus.FAILURE,
-        errorMessage: `Expected status [${testCase.expectedStatusCodes.join(
-          ","
-        )}], but got ${response.status}`,
-        mandatory: isMandatoryVersion(testCase, version),
-        testKey: testCase.testKey,
-        curlRequest: curlCmd,
-        documentationUrl: testCase.documentationUrl,
-      };
-    }
-
-    const rawResponse = await response.text();
-
-    let responseData;
-    responseData = rawResponse.length > 0 ? JSON.parse(rawResponse) : "";
-
-    logger.info(`Test response data from ${url}`, responseData);
-
-    // Validate the response JSON using AJV if a schema is provided.
-    if (testCase.schema) {
-      const ajv = new Ajv({ allErrors: true });
-      addFormats(ajv);
-      betterErrors(ajv);
-      const validate = ajv.compile(testCase.schema);
-      const valid = validate(responseData);
-      if (!valid) {
-        logger.info(
-          "Schema validation failed:",
-          validate.errors?.map((e) => e.message).join(", ") as any
-        );
-        return {
-          name: testCase.name,
-          status: TestCaseResultStatus.FAILURE,
-          errorMessage: `Schema validation failed: ${JSON.stringify(
-            validate.errors
-          )}`,
-          apiResponse: JSON.stringify(responseData),
-          mandatory: isMandatoryVersion(testCase, version),
-          testKey: testCase.testKey,
-          curlRequest: curlCmd,
-          documentationUrl: testCase.documentationUrl,
-        };
-      }
-    }
-
-    logger.info("Schema validation passed");
-
-    // Run condition if provided
-    if (typeof testCase.condition === "function") {
-      const conditionPassed = testCase.condition(
-        responseData,
-        response.headers
-      );
-      if (!conditionPassed) {
-        return {
-          name: testCase.name,
-          status: TestCaseResultStatus.FAILURE,
-          errorMessage: testCase.conditionErrorMessage,
-          apiResponse: JSON.stringify(responseData),
-          mandatory: isMandatoryVersion(testCase, version),
-          testKey: testCase.testKey,
-          curlRequest: curlCmd,
-          documentationUrl: testCase.documentationUrl,
-        };
-      }
-    }
-
-    return {
-      name: testCase.name,
-      status: TestCaseResultStatus.SUCCESS,
-      mandatory: isMandatoryVersion(testCase, version),
-      testKey: testCase.testKey,
-      curlRequest: curlCmd,
-      documentationUrl: testCase.documentationUrl,
-    };
-  } catch (error: any) {
-    // Check if the error is due to timeout
-    const isTimeoutError = error.name === "AbortError";
-    const errorMessage = isTimeoutError
-      ? `Request timeout after ${config.TESTCASE_TIMEOUT}ms`
-      : error.message;
-
-    logger.info((testCase.expectHttpError ?? "").toString(), error);
-
-    return {
-      name: testCase.name,
-      // If we expect an HTTP error, we consider the test successful if the request fails
-      status:
-        testCase.expectHttpError === true
-          ? TestCaseResultStatus.SUCCESS
-          : TestCaseResultStatus.FAILURE,
-      // If we expect an HTTP error, we don't return an error message
-      ...(testCase.expectHttpError === true
-        ? {}
-        : { errorMessage: errorMessage }),
-      mandatory: isMandatoryVersion(testCase, version),
-      testKey: testCase.testKey,
-      curlRequest: curlCmd,
-      documentationUrl: testCase.documentationUrl,
-    };
   }
+  catch (error: any) {
+    if (error.name === "AbortError"){
+      result.errorMessage = `Request timeout after ${config.TESTCASE_TIMEOUT}ms`;
+    } else {
+      result.errorMessage = error.message;
+    }
+    if (testCase.expectHttpError) {
+      result.status = TestCaseResultStatus.SUCCESS;
+    } else {
+      result.status = TestCaseResultStatus.FAILURE;
+    }
+    return result;
+  }
+
+  if (testCase.expectHttpError) {
+    if (status >= 200 && status < 300) {
+      result.errorMessage = `Expected HTTP error, but got ${status}`;
+    } else {
+      result.status = TestCaseResultStatus.SUCCESS;
+    }
+    return result;
+  }
+
+  result.apiResponse = JSON.stringify(data);
+  
+  if (testCase.expectedStatusCodes && !testCase.expectedStatusCodes.includes(status)) {
+    result.status = TestCaseResultStatus.FAILURE;
+    result.errorMessage = `Expected status [${testCase.expectedStatusCodes.join(", ")}], but got ${status}`;
+    return result;
+  }
+  
+  if (testCase.schema) {
+    const ajv = new Ajv({ allErrors: true });
+    addFormats(ajv);
+    betterErrors(ajv);
+    const validate = ajv.compile(testCase.schema);
+    if (!validate(data)) {
+      logger.info(
+        "Schema validation failed:",
+        validate.errors?.map((e) => e.message).join(", ") as any
+      );
+      result.status = TestCaseResultStatus.FAILURE;
+      result.errorMessage = `Schema validation failed: ${JSON.stringify(validate.errors)}`;
+      return result;
+    }
+  }
+
+  // Run condition if provided
+  if (typeof testCase.condition === "function") {
+    let messages:string[] = [];
+    if (!testCase.condition(data, messages)) {
+      result.status = TestCaseResultStatus.FAILURE;
+      if (testCase.conditionErrorMessage) {
+        messages.push(testCase.conditionErrorMessage);
+      }
+    } else {
+      result.status = TestCaseResultStatus.SUCCESS;
+    }
+    result.errorMessage = messages.join(", ");
+  }
+
+  return result;
 };


### PR DESCRIPTION
If a to-be-tested API is missing a json error object in test cases 6,7,16, the conformance tool will now issues a warning, and will NOT fail the tests, as long as the HTTP status code 400 or 401 is returned. 

See #167.

This change can be merged after discussion in the Tech WG 1 Oct 2025.