### PR TITLE
fix: update test status with the correct test-run id

### DIFF
--- a/src/controllers/eventController.ts
+++ b/src/controllers/eventController.ts
@@ -172,7 +172,7 @@ export class EventController {
             existingTestRun.results
           );
           await updateTestRunStatus(
-            req.body.data.requestEventId,
+            testRunId,
             testRunStatus,
             passingPercentage
           );
@@ -245,7 +245,7 @@ export class EventController {
             existingTestRunForRejected.results
           );
           await updateTestRunStatus(
-            req.body.data.requestEventId,
+            testRunId,
             testRunStatus,
             passingPercentage
           );


### PR DESCRIPTION
After receiving a callback event the conformance tool needs to update the status of the related testrun, the id of which can be derived from the callback event id. However, since #187 the callback events receive unique IDs consisting of `testRunId` + `testNumber`. This fix resolves the issue where the old request Ids where used to update the test run status. 
The function for updating the status now gets called with the correct `testRunId`