### PR TITLE
Ensure parsing of content-type cloudevents+json for /events

### DIFF
--- a/src/server.ts
+++ b/src/server.ts
@@ -16,7 +16,7 @@ const app = express();
 const port = process.env.PORT || 8080;
 
 // Middleware for parsing JSON bodies
-app.use(express.json());
+app.use(express.json({type: ["application/json", "application/cloudevents+json"]}));
 
 // Logging middleware
 app.use(loggerMiddleware);


### PR DESCRIPTION
This pull request makes a small change to the JSON body parsing middleware in the `src/server.ts` file. The change updates the configuration to allow the server to accept both standard JSON and CloudEvents JSON payloads.
Fixes #199 