### PR TITLE
Fix/211 test case 8 UUID format badrequest responses

### DIFF
--- a/src/test-cases/v2-test-cases.ts
+++ b/src/test-cases/v2-test-cases.ts
@@ -141,7 +141,7 @@ export const generateV2TestCases = async ({
     {
       name: "Test Case 8: Attempt GetFootprint with Non-Existent PfId",
       method: "GET",
-      endpoint: `/2/footprints/random-string-as-id-${randomString(16)}`,
+      endpoint: "/2/footprints/00000000-0000-0000-0000-000000000000",
       expectedStatusCodes: [400, 404],
       condition: (body) => {
         return body?.code === "NoSuchFootprint" || body?.code === "BadRequest";

--- a/src/test-cases/v2-test-cases.ts
+++ b/src/test-cases/v2-test-cases.ts
@@ -144,7 +144,7 @@ export const generateV2TestCases = async ({
       endpoint: `/2/footprints/random-string-as-id-${randomString(16)}`,
       expectedStatusCodes: [400, 404],
       condition: (body) => {
-        return body?.code === "NoSuchFootprint";
+        return body?.code === "NoSuchFootprint" || body?.code === "BadRequest";
       },
       conditionErrorMessage: `Expected error code NoSuchFootprint in response.`,
       mandatoryVersion: ["V2.0", "V2.1", "V2.2", "V2.3"],

--- a/src/test-cases/v3-test-cases.ts
+++ b/src/test-cases/v3-test-cases.ts
@@ -230,7 +230,7 @@ export const generateV3TestCases = async ({
     {
       name: "Test Case 8: Attempt GetFootprint with Non-Existent PfId",
       method: "GET",
-      endpoint: `/3/footprints/random-string-as-id-${randomString(16)}`,
+      endpoint: "/3/footprints/00000000-0000-0000-0000-000000000000",
       expectedStatusCodes: [400, 404],
       condition: (body) => {
         return body?.code === "NotFound" || body?.code === "BadRequest";

--- a/src/test-cases/v3-test-cases.ts
+++ b/src/test-cases/v3-test-cases.ts
@@ -233,7 +233,7 @@ export const generateV3TestCases = async ({
       endpoint: `/3/footprints/random-string-as-id-${randomString(16)}`,
       expectedStatusCodes: [400, 404],
       condition: (body) => {
-        return body?.code === "NotFound";
+        return body?.code === "NotFound" || body?.code === "BadRequest";
       },
       conditionErrorMessage: `Expected error code NotFound in response.`,
       mandatoryVersion: ["V3.0"],


### PR DESCRIPTION
Updated **Test Case 8** (GetFootprint with Non-Existent PfId) for V2 and V3. The changes standardize the test to use a clearly invalid UUID and expand the accepted error codes to account for possible variations in API responses.

Test case updates for non-existent footprint ID:

* In `src/test-cases/v2-test-cases.ts`, updated the endpoint to use a fixed all-zero UUID (`00000000-0000-0000-0000-000000000000`) instead of a random string, and expanded the accepted error codes to include both `NoSuchFootprint` and `BadRequest` in the condition.
* In `src/test-cases/v3-test-cases.ts`, similarly updated the endpoint to use the all-zero UUID and expanded the accepted error codes to include both `NotFound` and `BadRequest` in the condition.