### PR TITLE
Fix/212 test 18 fails when OpenId Connect url matches base url

### DIFF
--- a/src/services/test-run-worker.ts
+++ b/src/services/test-run-worker.ts
@@ -39,6 +39,10 @@ export class TestRunWorker {
     if (!params.baseUrl || !params.clientId || !params.clientSecret) {
       throw new ValidationError("Missing required parameters: baseUrl, clientId, and clientSecret are mandatory.");
     }
+    // Remove trailing slashes from URLs, and lowercase protocol part for http/https tests to work correctly
+    params.baseUrl = params.baseUrl.replace(/\/+$/, "").replace(/^https:/i, "https:");
+    params.customAuthBaseUrl = params.customAuthBaseUrl?.replace(/\/+$/, "").replace(/^https:/i, "https:");
+    
     await this.output.saveTestRun({
       testRunId,
       ...params,

--- a/src/test-cases/v2-test-cases.ts
+++ b/src/test-cases/v2-test-cases.ts
@@ -343,7 +343,8 @@ export const generateV2TestCases = async ({
     {
       name: "Test Case 18: OpenId Connect-based Authentication Flow",
       method: "POST",
-      customUrl: authTokenUrl.startsWith(baseUrl) ? undefined : authTokenUrl, // Skip if authTokenUrl is under the baseUrl, will not be an OpenID provider then
+      endpoint: "/auth/token",
+      customUrl: authTokenUrl.startsWith(baseUrl) ? undefined : authTokenUrl, // Fall back to using endpoint (/auth/token) if authTokenUrl is under the baseUrl.
       expectedStatusCodes: [200],
       headers: getCorrectAuthHeaders(baseUrl, clientId, clientSecret),
       testKey: "TESTCASE#18",
@@ -354,7 +355,8 @@ export const generateV2TestCases = async ({
     {
       name: "Test Case 19: OpenId connect-based authentication flow with incorrect credentials",
       method: "POST",
-      customUrl: authTokenUrl.startsWith(baseUrl) ? undefined : authTokenUrl, // Skip if authTokenUrl is under the baseUrl, will not be an OpenID provider then
+      endpoint: "/auth/token",
+      customUrl: authTokenUrl.startsWith(baseUrl) ? undefined : authTokenUrl, // Fall back to using endpoint (/auth/token) if authTokenUrl is under the baseUrl.
       expectedStatusCodes: [400, 401],
       headers: getIncorrectAuthHeaders(baseUrl),
       testKey: "TESTCASE#19",

--- a/src/test-cases/v3-test-cases.ts
+++ b/src/test-cases/v3-test-cases.ts
@@ -443,7 +443,8 @@ export const generateV3TestCases = async ({
     {
       name: "Test Case 18: OpenId Connect-based Authentication Flow",
       method: "POST",
-      customUrl: authTokenUrl.startsWith(baseUrl) ? undefined : authTokenUrl, // Skip if authTokenUrl is under the baseUrl, will not be an OpenID provider then
+      endpoint: "/auth/token",
+      customUrl: authTokenUrl.startsWith(baseUrl) ? undefined : authTokenUrl, // Fall back to using endpoint (/auth/token) if authTokenUrl is under the baseUrl.
       expectedStatusCodes: [200],
       headers: getCorrectAuthHeaders(baseUrl, clientId, clientSecret),
       testKey: "TESTCASE#18",
@@ -454,7 +455,8 @@ export const generateV3TestCases = async ({
     {
       name: "Test Case 19: OpenId connect-based authentication flow with incorrect credentials",
       method: "POST",
-      customUrl: authTokenUrl.startsWith(baseUrl) ? undefined : authTokenUrl, // Skip if authTokenUrl is under the baseUrl, will not be an OpenID provider then
+      endpoint: "/auth/token",
+      customUrl: authTokenUrl.startsWith(baseUrl) ? undefined : authTokenUrl, // Fall back to using endpoint (/auth/token) if authTokenUrl is under the baseUrl.
       expectedStatusCodes: [400, 401],
       headers: getIncorrectAuthHeaders(baseUrl),
       testKey: "TESTCASE#19",


### PR DESCRIPTION
Fixes test case edge case for for OpenID Connect authentication flow. See #212. 

* Trailing slashes are removed and the protocol part is forced to lowercase for both `baseUrl` and `customAuthBaseUrl` in `TestRunWorker` to ensure consistent URL handling and prevent issues during HTTP/HTTPS tests.
* In both `generateV2TestCases` and `generateV3TestCases`, for OpenID Connect test cases (Test Cases 18 and 19), the `endpoint` is explicitly set to `/auth/token`, and `customUrl` will only be used if it differs from `baseUrl`. This ensures that when the auth token URL is under the base URL, the test falls back to the standard endpoint.