### PR TITLE
CLI tool: added --testCases parameter for testing partial solutions along the way

### DIFF
--- a/docs/cli-examples.md
+++ b/docs/cli-examples.md
@@ -13,6 +13,19 @@ npm run cli -- \
   --organizationName "Your Organization"
 ```
 
+During initial development, it's helpful to be able to assert that certain test
+cases are covered with the `--testCases` command line option:
+
+```bash
+npm run cli -- \
+  --baseUrl https://api.example.com \
+  --clientId your-client-id \
+  --clientSecret your-client-secret \
+  --version V3.0 \
+  --organizationName "Your Organization" \
+  --testCases 1-2,9                          # only test authentication flow
+```
+
 ## V2.2 Tests with Custom Auth
 
 ```bash

--- a/src/scripts/run-tests-cli.ts
+++ b/src/scripts/run-tests-cli.ts
@@ -32,6 +32,27 @@ import { ConsoleTestStorage } from "../services/console-test-storage";
 import { ApiVersion, TestRunStartParams } from "../services/types";
 import logger from "../utils/logger";
 
+/**
+ * Parses a comma-separated list of test case numbers and ranges (e.g. "1-2,9" -> [1, 2, 9]).
+ */
+function parseTestCaseList(raw: string): number[] {
+  const result: number[] = [];
+  for (const part of raw.split(",").map((s) => s.trim()).filter(Boolean)) {
+    const dash = part.indexOf("-");
+    if (dash >= 0) {
+      const lo = parseInt(part.slice(0, dash).trim(), 10);
+      const hi = parseInt(part.slice(dash + 1).trim(), 10);
+      if (!Number.isNaN(lo) && !Number.isNaN(hi) && lo <= hi) {
+        for (let n = lo; n <= hi; n++) result.push(n);
+      }
+    } else {
+      const n = parseInt(part, 10);
+      if (!Number.isNaN(n)) result.push(n);
+    }
+  }
+  return [...new Set(result)].sort((a, b) => a - b);
+}
+
 function parseArgs(): TestRunStartParams {
   const args = process.argv.slice(2);
   const params: Partial<TestRunStartParams> = {
@@ -88,6 +109,12 @@ function parseArgs(): TestRunStartParams {
         params.adminName = value;
         i++;
         break;
+      case "--testCases": {
+        const raw = value ?? "";
+        params.testCaseNumbers = parseTestCaseList(raw);
+        i++;
+        break;
+      }
       case "--help":
       case "-h":
         printHelp();
@@ -135,6 +162,7 @@ Optional Options:
   --resource <resource>        OAuth resource
   --adminEmail <email>         Admin email address (default: cli@example.com)
   --adminName <name>           Admin name (default: CLI User)
+  --testCases <list>           Comma-separated numbers and ranges (e.g. 1-2,9). Omit to run all.
   --help, -h                   Show this help message
 
 Examples:
@@ -155,6 +183,15 @@ Examples:
     --version V2.2 \\
     --organizationName "My Company" \\
     --scope "read:footprints"
+
+  # Run only test cases 1, 2, and 9
+  npx tsx src/scripts/run-tests-cli.ts \\
+    --baseUrl https://api.example.com \\
+    --clientId myClientId \\
+    --clientSecret mySecret \\
+    --version V3.0 \\
+    --organizationName "My Company" \\
+    --testCases 1-2,9
   `);
 }
 

--- a/src/services/test-run-worker.ts
+++ b/src/services/test-run-worker.ts
@@ -99,9 +99,20 @@ export class TestRunWorker {
     };
 
     // Generate test cases based on the version
-    const testCases = params.version.startsWith("V2")
+    let testCases = params.version.startsWith("V2")
       ? await generateV2TestCases(testRunParams)
       : await generateV3TestCases(testRunParams);
+
+    // Filter to specific test case numbers if requested (e.g. testKey "TESTCASE#1" -> 1)
+    if (params.testCaseNumbers?.length) {
+      const allowed = new Set(params.testCaseNumbers);
+      testCases = testCases.filter((tc) => {
+        const match = tc.testKey.match(/^TESTCASE#(\d+)/);
+        const num = match ? parseInt(match[1], 10) : null;
+        return num !== null && allowed.has(num);
+      });
+      logger.info(`Filtered to test cases: ${params.testCaseNumbers.join(", ")} (${testCases.length} cases)`);
+    }
 
     const results: TestResult[] = [];
 

--- a/src/services/types.ts
+++ b/src/services/types.ts
@@ -75,6 +75,7 @@ export interface TestRunStartParams {
   scope?: string;
   audience?: string;
   resource?: string;
+  testCaseNumbers?: number[];
 }
 
 export interface TestRun {


### PR DESCRIPTION
As we have been updating from v2 -> v3, it was helpful to be able to list the `--testCases` parameter on the command line so that we could partially test or solution along the way. I added documentation for this to the CLI docs

This builds on @schuur's #218 PR.