### PR TITLE
Clarify how to authenticate on event API callback

### DIFF
--- a/docs/v3-test-cases-expected-results.md
+++ b/docs/v3-test-cases-expected-results.md
@@ -478,6 +478,8 @@ Content-Type: application/cloudevents+json; charset=UTF-8
 authorization: Bearer [BearerToken]
 ```
 
+> NOTE: The BearerToken for the incoming request should be obtained from the PACT Conformance Testing Service. See [FAQ](./FAQ) for more details.
+
 Expected *incoming* Request body:
 
 ```
@@ -595,6 +597,8 @@ Expected *incoming* Request headers:
 Content-Type: application/cloudevents+json; charset=UTF-8
 authorization: Bearer [BearerToken]
 ```
+
+> NOTE: The BearerToken for the incoming request should be obtained from the PACT Conformance Testing Service. See [FAQ](./FAQ) for more details.
 
 Expected *incoming* Request body:
 


### PR DESCRIPTION
It wasn't immediately obvious to me how to authenticate back to the PACT Conformance Service for tests TC#13 and TC#14.B. This adds a note to the corresponding test case documentation with a reference to the FAQ, but I'm happy to adapt this in whatever way makes the most sense for others to use.